### PR TITLE
[WIP] Adds cassandra support for token cache

### DIFF
--- a/auth_cache.py
+++ b/auth_cache.py
@@ -1,0 +1,160 @@
+import abc
+import ssl
+import time
+import uuid
+
+from cassandra import auth
+from cassandra import cluster
+from cassandra import policies
+from cassandra import query
+import moecache
+import six
+
+
+@six.add_metaclass(abc.ABCMeta)
+class AuthCacheBase(object):
+    def __init__(self, config, logger):
+        self.prefix = config.get('authcache', 'authtoken-prefix')
+        self.logger = logger
+
+    def get(self, token):
+        """Retrieve token from cache."""
+        raise NotImplementedError
+
+    def set(self, token):
+        """Set token in cache."""
+        raise NotImplementedError
+
+    def auth(self, token):
+        """Check if token exists."""
+        if self.get(token) is not None:
+            return True
+        else:
+            return False
+
+    def connected(self):
+        """Check that we can successfully set and get a token."""
+        key = str(uuid.uuid4())
+        self.set(key)
+        return self.auth(key)
+
+
+class CassandraAuthCache(AuthCacheBase):
+    def __init__(self, config, logger):
+        super(CassandraAuthCache, self).__init__(config, logger)
+        raw_cluster = config.get("cassandra", "cluster")
+        cluster_ips = [addr for addr in raw_cluster.split(',')]
+        self.keyspace = config.get("cassandra", "keyspace")
+
+        port = config.getint("cassandra", "port")
+
+        if config.getboolean("cassandra", "ssl_enabled"):
+            cert_path = config.get("cassandra", "ssl_ca_certs")
+            ssl_options = {
+                'ca_certs': cert_path,
+                'ssl_version': ssl.PROTOCOL_TLSv1
+            }
+        else:
+            ssl_options = None
+
+        if config.getboolean("cassandra", "auth_enabled"):
+            username = config.get("cassandra", "username")
+            password = config.get("cassandra", "password")
+
+            auth_provider = auth_provider = auth.PlainTextAuthProvider(
+                username=username,
+                password=password
+            )
+        else:
+            auth_provider = None
+
+        load_balance_strategy = config.get(
+            "cassandra",
+            "load_balance_strategy"
+        )
+        load_balancing_policy_class = getattr(policies, load_balance_strategy)
+        if load_balancing_policy_class is policies.DCAwareRoundRobinPolicy:
+            datacenter = config.get("cassandra", "datacenter")
+            load_balancing_policy = load_balancing_policy_class(datacenter)
+        else:
+            load_balancing_policy = load_balancing_policy_class()
+
+        self.cassandra_cluster = cluster.Cluster(
+            cluster_ips,
+            auth_provider=auth_provider,
+            load_balancing_policy=load_balancing_policy,
+            port=port,
+            ssl_options=ssl_options
+        )
+
+        # In case cassandra is not up prior to running RSE, retry every 5 sec
+        connected = False
+        while not connected:
+            try:
+                self.session = self.cassandra_cluster.connect()
+                connected = True
+            except Exception:
+                time.sleep(5)
+
+        self.session.row_factory = query.dict_factory
+
+    def get(self, token):
+        # TODO(Kuwagata) Add consistency failover
+        rows = self.session.execute(
+            """SELECT * FROM {0}.auth_token_cache WHERE api_key = %(token)s
+            """.format(self.keyspace),
+            {
+                "token": (self.prefix + token),
+            }
+        )
+        if len(rows) > 0:
+            self.logger.debug("CASSANDRA GET: " + str(rows))
+            return rows
+        else:
+            return None
+
+    def set(self, token):
+        self.session.execute(
+            """INSERT INTO {0}.auth_token_cache
+            (
+                api_key
+            )
+            VALUES
+            (
+                %(token)s
+            )
+            """.format(self.keyspace),
+            {
+                "token": (self.prefix + token),
+            }
+        )
+
+
+class MemcachedAuthCache(AuthCacheBase):
+    def __init__(self, config, logger):
+        super(MemcachedAuthCache, self).__init__(config, logger)
+
+        raw_shards = config.get('memcached', 'memcached-shards')
+        timeout = config.getint('memcached', 'memcached-timeout')
+
+        shards = [
+            (host, int(port))
+            for host, port in
+            [
+                addr.split(':')
+                for addr in
+                raw_shards.split(',')
+            ]
+        ]
+
+        self.client = moecache.Client(
+            shards,
+            timeout=timeout
+        )
+
+    def get(self, token):
+        return self.client.get(token)
+
+    def set(self, token):
+        # ttl is unconfigured since set is only used for online status
+        self.client.set(token, 1, 60)

--- a/controllers/main_controller.py
+++ b/controllers/main_controller.py
@@ -37,9 +37,8 @@ def format_datetime(dt):
 class MainController(rawr.Controller):
     """Provides all RSE functionality"""
 
-    def __init__(self, mongo_db, shared, authtoken_prefix, test_mode=False):
+    def __init__(self, mongo_db, shared, test_mode=False):
         self.mongo_db = mongo_db  # MongoDB database for storing events
-        self.authtoken_prefix = authtoken_prefix
         self.test_mode = test_mode  # If true, relax auth/uuid requirements
         self.shared = shared  # Shared performance counters, logging, etc.
 
@@ -57,8 +56,7 @@ class MainController(rawr.Controller):
 
         # See if auth is cached by API
         try:
-            if (self.shared.authtoken_cache.get(
-                self.authtoken_prefix + auth_token) is None):
+            if self.shared.authtoken_cache.auth(auth_token) is False:
                 raise HttpUnauthorized()
 
         except HttpError:

--- a/rse.default.conf
+++ b/rse.default.conf
@@ -9,9 +9,24 @@ test = yes
 event-ttl = 120
 
 [authcache]
+provider = memcached
 authtoken-prefix = QuattroAPI_Login_Ticket_
+
+[memcached]
 memcached-shards = 127.0.0.1:11211
 memcached-timeout = 5
+
+[cassandra]
+cluster = 1.2.3.4,10.11.12.13,127.0.0.1
+port = 9042
+ssl_enabled = False
+ssl_ca_certs = /path/to/cert
+auth_enabled = False
+username = username_goes_here
+password = password_goes_here
+load_balance_strategy = DCAwareRoundRobinPolicy
+datacenter = DC_NAME
+keyspace = auth_token_cache
 
 [logging]
 console = yes


### PR DESCRIPTION
Auth tokens may be stored in a cassandra instance rather than in memcached, allowing for a global cache when using multiple instances of RSE.
