### PR TITLE
Adds cassandra support for token cache

### DIFF
--- a/auth_cache.py
+++ b/auth_cache.py
@@ -1,0 +1,197 @@
+import abc
+import ssl
+import time
+import uuid
+
+import cassandra
+from cassandra import auth
+from cassandra import cluster
+from cassandra import policies
+from cassandra import query
+import moecache
+import six
+
+
+@six.add_metaclass(abc.ABCMeta)
+class AuthCacheBase(object):
+    def __init__(self, config, logger):
+        self.prefix = config.get('authcache', 'authtoken-prefix')
+        self.default_ttl = config.getint('authcache', 'default_ttl')
+        self.logger = logger
+
+    def get(self, token):
+        """Retrieve token from cache."""
+        raise NotImplementedError
+
+    def set(self, token, ttl=None):
+        """Set token in cache."""
+        raise NotImplementedError
+
+    def auth(self, token):
+        """Check if token exists."""
+        return self.get(token) is not None
+
+    def connected(self):
+        """Check that we can successfully set and get a token."""
+        key = str(uuid.uuid4())
+        self.set(key)
+        return self.auth(key)
+
+    def _get_ttl(self, ttl):
+        if ttl is None:
+            return self.default_ttl
+        else:
+            try:
+                return int(ttl)
+            except ValueError:
+                raise ValueError("invalid integer for ttl: {0}".format(ttl))
+
+
+class CassandraAuthCache(AuthCacheBase):
+    def __init__(self, config, logger):
+        super(CassandraAuthCache, self).__init__(config, logger)
+        raw_cluster = config.get("cassandra", "cluster")
+        cluster_ips = [addr for addr in raw_cluster.split(',')]
+        self.keyspace = config.get("cassandra", "keyspace")
+        max_connect_retries = config.getint("cassandra", "max_retries")
+
+        port = config.getint("cassandra", "port")
+
+        if config.getboolean("cassandra", "ssl_enabled"):
+            cert_path = config.get("cassandra", "ssl_ca_certs")
+            ssl_options = {
+                'ca_certs': cert_path,
+                'ssl_version': ssl.PROTOCOL_TLSv1
+            }
+        else:
+            ssl_options = None
+
+        if config.getboolean("cassandra", "auth_enabled"):
+            username = config.get("cassandra", "username")
+            password = config.get("cassandra", "password")
+
+            auth_provider = auth_provider = auth.PlainTextAuthProvider(
+                username=username,
+                password=password
+            )
+        else:
+            auth_provider = None
+
+        load_balance_strategy = config.get(
+            "cassandra",
+            "load_balance_strategy"
+        )
+        load_balancing_policy_class = getattr(policies, load_balance_strategy)
+        if load_balancing_policy_class is policies.DCAwareRoundRobinPolicy:
+            datacenter = config.get("cassandra", "datacenter")
+            load_balancing_policy = load_balancing_policy_class(datacenter)
+        else:
+            load_balancing_policy = load_balancing_policy_class()
+
+        self.cassandra_cluster = cluster.Cluster(
+            cluster_ips,
+            auth_provider=auth_provider,
+            load_balancing_policy=load_balancing_policy,
+            port=port,
+            ssl_options=ssl_options
+        )
+
+        # In case cassandra is not up prior to running RSE, retry every 5 sec
+        for i in range(max_connect_retries):
+            try:
+                self.session = self.cassandra_cluster.connect()
+            except Exception:
+                time.sleep(5)
+
+        self.session.row_factory = query.dict_factory
+
+    def get(self, token):
+        select_statement = """SELECT *
+            FROM {0}.auth_token_cache
+            WHERE api_key = %(token)s
+        """.format(self.keyspace)
+
+        args = {
+            "token": (self.prefix + token),
+        }
+
+        try:
+            rows = self.session.execute(
+                query.SimpleStatement(
+                    select_statement,
+                    consistency_level=cassandra.ConsistencyLevel.LOCAL_ONE
+                ),
+                args
+            )
+        except Exception:
+            try:
+                rows = self.session.execute(
+                    query.SimpleStatement(
+                        select_statement,
+                        consistency_level=(
+                            cassandra.ConsistencyLevel.LOCAL_QUORUM
+                        )
+                    ),
+                    args
+                )
+            except Exception:
+                self.logger.exception(
+                    "Failover to LOCAL_QUORUM failed for %s",
+                    args["token"]
+                )
+                raise
+        if len(rows) > 0:
+            return rows
+        else:
+            return None
+
+    def set(self, token, ttl=None):
+        insert_statement = query.SimpleStatement(
+            """INSERT INTO {0}.auth_token_cache
+            (
+                api_key
+            )
+            VALUES
+            (
+                %(token)s
+            )
+            USING TTL %(ttl)s
+            """
+        )
+
+        self.session.execute(
+            insert_statement,
+            {
+                "token": (self.prefix + token),
+                "ttl": self._get_ttl(ttl),
+            }
+        )
+
+
+class MemcachedAuthCache(AuthCacheBase):
+    def __init__(self, config, logger):
+        super(MemcachedAuthCache, self).__init__(config, logger)
+
+        raw_shards = config.get('memcached', 'memcached-shards')
+        timeout = config.getint('memcached', 'memcached-timeout')
+
+        shards = [
+            (host, int(port))
+            for host, port in
+            [
+                addr.split(':')
+                for addr in
+                raw_shards.split(',')
+            ]
+        ]
+
+        self.client = moecache.Client(
+            shards,
+            timeout=timeout
+        )
+
+    def get(self, token):
+        return self.client.get(self.prefix + token)
+
+    def set(self, token, ttl=None):
+        self.client.set(self.prefix + token, 1, self._get_ttl(ttl))

--- a/controllers/main_controller.py
+++ b/controllers/main_controller.py
@@ -37,9 +37,8 @@ def format_datetime(dt):
 class MainController(rawr.Controller):
     """Provides all RSE functionality"""
 
-    def __init__(self, mongo_db, shared, authtoken_prefix, test_mode=False):
+    def __init__(self, mongo_db, shared, test_mode=False):
         self.mongo_db = mongo_db  # MongoDB database for storing events
-        self.authtoken_prefix = authtoken_prefix
         self.test_mode = test_mode  # If true, relax auth/uuid requirements
         self.shared = shared  # Shared performance counters, logging, etc.
 
@@ -57,8 +56,7 @@ class MainController(rawr.Controller):
 
         # See if auth is cached by API
         try:
-            if (self.shared.authtoken_cache.get(
-                self.authtoken_prefix + auth_token) is None):
+            if not self.shared.authtoken_cache.auth(auth_token):
                 raise HttpUnauthorized()
 
         except HttpError:

--- a/rse.default.conf
+++ b/rse.default.conf
@@ -9,9 +9,26 @@ test = yes
 event-ttl = 120
 
 [authcache]
+provider = memcached
 authtoken-prefix = QuattroAPI_Login_Ticket_
+default_ttl = 600
+
+[memcached]
 memcached-shards = 127.0.0.1:11211
 memcached-timeout = 5
+
+[cassandra]
+cluster = 1.2.3.4,10.11.12.13,127.0.0.1
+port = 9042
+ssl_enabled = False
+ssl_ca_certs = /path/to/cert
+auth_enabled = False
+username = username_goes_here
+password = password_goes_here
+load_balance_strategy = DCAwareRoundRobinPolicy
+datacenter = DC_NAME
+max_retries = 20
+keyspace = auth_token_cache
 
 [logging]
 console = yes

--- a/rse.py
+++ b/rse.py
@@ -27,10 +27,10 @@ import ConfigParser
 
 import pymongo
 import argparse
-import moecache
 
 from rax.http import rawr
 
+import auth_cache
 from controllers.shared import *
 from controllers.health_controller import *
 from controllers.main_controller import *
@@ -96,13 +96,20 @@ class RseApplication(rawr.Rawr):
 
         # FastCache for Auth Token
         authtoken_prefix = config.get('authcache', 'authtoken-prefix')
-        memcached_shards = [(host, int(port)) for host, port in
-                            [addr.split(':') for addr in
-                             config.get('authcache',
-                                        'memcached-shards').split(',')]]
-        memcached_timeout = config.getint('authcache', 'memcached-timeout')
-        authtoken_cache = moecache.Client(memcached_shards,
-                                          timeout=memcached_timeout)
+        provider = config.get('authcache', 'provider')
+        logger.debug(
+            {
+                'token prefix': authtoken_prefix,
+                'cache provider': provider,
+            }
+        )
+        if provider == 'memcached':
+            authtoken_cache = auth_cache.MemcachedAuthCache(config, logger)
+        elif provider == 'cassandra':
+            authtoken_cache = auth_cache.CassandraAuthCache(config, logger)
+        else:
+            logger.error('No auth_cache provider for: %s', provider)
+            sys.exit(1)
 
         # Connnect to MongoDB
         mongo_db, mongo_db_master = self.init_database(logger, config)
@@ -120,7 +127,6 @@ class RseApplication(rawr.Rawr):
 
         main_options = dict(shared=shared,
                             mongo_db=mongo_db,
-                            authtoken_prefix=authtoken_prefix,
                             test_mode=test_mode)
         self.add_route(r"/.+", MainController, main_options)
 


### PR DESCRIPTION
Auth tokens may be stored in a cassandra instance rather than in memcached, allowing for a global cache when using multiple instances of RSE.
