### PR TITLE
Adds docker-compose scalability to rse

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,11 @@ ADD . /home/rse
 # rse configurations
 ADD rse.docker.conf /etc/rse.conf
 
+# Deploy startup script
+ADD docker_init.sh /usr/local/bin/rse-docker
+RUN chmod 755 /usr/local/bin/rse-docker
+
 EXPOSE 8000
 
 WORKDIR /home/rse
-CMD ["gunicorn", "rse:app", "-b", "0.0.0.0:8000", "--log-file", "-", "--log-level", "debug"]
+CMD rse-docker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ rse:
         - cache
         - db
     ports:
-        - "8000:8000"
+        - "8000"
 db:
     image: mongo:2.4
     command: --smallfiles

--- a/docker_init.sh
+++ b/docker_init.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+sed -i.bak s/mongo_db_name/$(hostname)/ /etc/rse.conf
+cat /etc/rse.conf
+gunicorn rse:app -b 0.0.0.0:8000 --log-file - --log-level debug

--- a/rse.docker.template.conf
+++ b/rse.docker.template.conf
@@ -1,6 +1,6 @@
 [mongodb]
 uri = mongodb://db/
-database = rse
+database = mongo_db_name
 replica-set = [none]
 # replica-set = rse
 use_ssl = False


### PR DESCRIPTION
RSE can be scaled by calling docker-compose scale rse=3.  The docker container's hostname replaces the database name, allowing for multiple containers to communicate with the same database.
