### PR TITLE
Hashes auth token if longer than a cutoff

### DIFF
--- a/rse.default.conf
+++ b/rse.default.conf
@@ -10,6 +10,7 @@ event-ttl = 120
 
 [authcache]
 authtoken-prefix = QuattroAPI_Login_Ticket_
+token_hashing_threshold = 250
 memcached-shards = 127.0.0.1:11211
 memcached-timeout = 5
 

--- a/rse.docker.conf
+++ b/rse.docker.conf
@@ -10,6 +10,7 @@ event-ttl = 120
 
 [authcache]
 authtoken-prefix = QuattroAPI_Login_Ticket_
+token_hashing_threshold = 250
 memcached-shards = cache:11211
 memcached-timeout = 5
 

--- a/rse.py
+++ b/rse.py
@@ -104,6 +104,10 @@ class RseApplication(rawr.Rawr):
 
         # FastCache for Auth Token
         authtoken_prefix = config.get('authcache', 'authtoken-prefix')
+        token_hashing_threshold = config.get(
+            'authcache',
+            'token_hashing_threshold'
+        )
         memcached_shards = [
             (host, int(port))
             for host, port in [
@@ -138,6 +142,7 @@ class RseApplication(rawr.Rawr):
         main_options = dict(shared=shared_controller,
                             mongo_db=mongo_db,
                             authtoken_prefix=authtoken_prefix,
+                            token_hashing_threshold=token_hashing_threshold,
                             test_mode=test_mode)
         self.add_route(r"/.+", main_controller.MainController, main_options)
 


### PR DESCRIPTION
Long auth tokens can break memcached.  This change puts a cap on what gets inserted.
