### PR TITLE
Bug Fix: Mimic Clock

### DIFF
--- a/docker/mimic/rc.local.mimic
+++ b/docker/mimic/rc.local.mimic
@@ -2,7 +2,7 @@
 
 set -m
 
-/usr/local/bin/twistd -n mimic -v &
+/usr/local/bin/twistd -n mimic -r -v &
 
 sleep 5
 


### PR DESCRIPTION
Mimic Clock by default runs a fake clock that starts at Epoch 0. To get a real clock value so that Token Expirations will match a real clock for external usage we need to set the '-r' option when starting Mimic, thus allowing Repose to validate the tokens based on the Expiration Time.
