### PR TITLE
Allow full logging of HTTP traffic

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,6 +26,9 @@ RUN until apt-get install -y $(cat /root/install.apt.txt) \
 # Install RSE
 ADD . /root/rse
 WORKDIR /root/rse
+# It's a pain to get /var/log/rse's perms sorted out, so just symlink it
+# to root.
+RUN ln -s /root /var/log/rse
 COPY ./deps/*.pip.txt /root/deps/
 RUN dos2unix /root/deps/*.pip.txt
 RUN pip3 install -r /root/deps/docker.pip.txt

--- a/docker/logging.yaml
+++ b/docker/logging.yaml
@@ -1,6 +1,2 @@
 root:
   level: DEBUG
-
-handlers:
-  file:
-    filename: /root/rse.log  # Because /var/log/rse doesn't exist.

--- a/src/rse/config/logging.yaml
+++ b/src/rse/config/logging.yaml
@@ -16,6 +16,17 @@ root:
   handlers:
     - console
     - file
+
+loggers:
+  # When debugging, sometimes it is useful to log full http
+  # requests/responses. Putting them in the main log would make it
+  # unreadable, so we have a special logger for the purpose that points
+  # to a separate file.
+  rse.util.httplog:
+    propagate: false
+    handlers:
+      - http
+
 handlers:
   file:
     class: logging.handlers.WatchedFileHandler
@@ -29,6 +40,11 @@ handlers:
     class: logging.handlers.SysLogHandler
     formatter: std
     facility: LOG_USER
+  http:
+    class: logging.handlers.WatchedFileHandler
+    formatter: http
+    filename: /var/log/rse/http.log
+
 formatters:
   # 'brief' is intended for the simplest useful output, suitable for
   # viewing at the console. 'std' adds the logger name (typically
@@ -57,3 +73,9 @@ formatters:
     # As above, but with PID added, for multiple-worker deployments.
     format: "%(asctime)s.%(msecs)03d\t%(process)d\t%(levelname)s\t%(name)s:%(lineno)d\t%(message)s"
     datefmt: '%Y-%m-%dT%H:%M:%S'
+
+  # For http logs, use a recordjar-style format. That way it's still
+  # technically machine parseable, even if grepping it is hard.
+  http:
+    format: "%%%%\nTimestamp: %(asctime)s.%(msecs)03d\n%(message)s\n"
+    datefmt: '%Y-%m-%d %H:%M:%S'

--- a/src/rse/util.py
+++ b/src/rse/util.py
@@ -21,6 +21,7 @@ from pkg_resources import get_distribution
 
 
 log = logging.getLogger(__name__)
+httplog = logging.getLogger(__name__ + '.httplog')
 
 
 def time_id(offset_sec=0):
@@ -125,3 +126,8 @@ def initlog(path=None):
     log.info("LOGLEVEL ENABLED: INFO")
     log.debug("LOGLEVEL ENABLED: DEBUG")
     log.trace("LOGLEVEL ENABLED: TRACE")
+    if httplog.isEnabledFor(logging.TRACE):
+        msg = ('WARNING: HTTP REQUEST LOGGING ENABLED. If this message '
+               'appears more than once, you are running multiple RSE '
+               'workers and their request logs may interlace.')
+        log.warning(msg)

--- a/src/rse/util.py
+++ b/src/rse/util.py
@@ -14,6 +14,7 @@ import sys
 import time
 import logging
 import logging.config
+from functools import partial, partialmethod
 
 from . import config
 from pkg_resources import get_distribution
@@ -95,7 +96,27 @@ def versions_report():
 
 
 def initlog(path=None):
-    """ Set up logging """
+    """ Set up logging
+
+    This does some evil monkeypatching to create a "trace" loglevel and
+    make it usable like any other. The *right* way to do this is to
+    subclass Logger and use setLoggerClass, but I can't figure out a way
+    to guarantee that happens before any loggers are intantiated. This
+    does the job well enough.
+
+    Most of the method comes from this SO answer:
+    https://stackoverflow.com/a/35804945/
+    """
+
+    tracelvl = logging.DEBUG - 5
+    logcls = logging.getLoggerClass()
+    name = 'TRACE'
+
+    logging.TRACE = tracelvl
+    logging.addLevelName(tracelvl, name)
+    logging.trace = partial(logging.log, tracelvl)
+    logcls.trace = partialmethod(logcls.log, tracelvl)
+
     logconf = config.load('logging.yaml', path)
     logging.config.dictConfig(logconf)
     log.critical("LOGLEVEL ENABLED: CRITICAL")
@@ -103,3 +124,4 @@ def initlog(path=None):
     log.warn("LOGLEVEL ENABLED: WARN")
     log.info("LOGLEVEL ENABLED: INFO")
     log.debug("LOGLEVEL ENABLED: DEBUG")
+    log.trace("LOGLEVEL ENABLED: TRACE")


### PR DESCRIPTION
This adds a TRACE loglevel and logs all HTTP traffic at that level. The http logging goes to a separate file to avoid swamping the main log. Note that the logged data is "as RSE sees it", which may not be exactly how it was sent (e.g. if nginx fiddles with the headers). Note also that this should only be used for active debugging; it will eat disk at around 30GB/day if someone leaves it on.

I had to refactor some of rawr.py to make it work. I broke that into a separate commit (bdf5254 below) to make it easier to check that it doesn't change any actual behavior.