### PR TITLE
Allow the initial event ID to be specified

### DIFF
--- a/src/rse/config/rse.yaml
+++ b/src/rse/config/rse.yaml
@@ -13,9 +13,11 @@
 test_mode: false  # Disables auth checking and enables /all debug channel
 token_prefix: ''
 
-# You are unlikely to need to change these.
+# You are unlikely to need to change anything below here.
 database: rse
-event_ttl: 120
+event_ttl: 120   # Event expiry time in seconds.
+first_event: 1   # Starting event ID when initializing a new database.
+
 token_hashing_threshold: 250
 
 mongodb:


### PR DESCRIPTION
This will help with cutover. When clients query RSE for events, they specify the last event ID that they saw. Older events are omitted from RSE's response. If the event ID counter is reset (as when standing up a new database), agents stop receiving new events, as they all appear to be "older". In the control panel, affected agents appear to be disconnected.

This change allows RSE to specify the counter's starting value when initializing the database, via a configuration option. For cutover purposes, it should be set at or above the current value of the counter in the old database.